### PR TITLE
Add optional health endpoint to check the application health

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It runs fine on OpenShift and binds port 8080 per default.
 - `IPS_ACCESS_WHITELIST` optional comma separated list of IPs/subnets that are allowed to access the proxy
 - `REMOTE_USER_REGEX` optional regex the `REMOTE_USER` must match against (e.g. `!@example.net$`)
 - `LOG_LEVEL` optional log level for Apache (default is `info`)
-- `HEALTHCHECK_ENABLED` when enabled, this will proxy /health to the given target path (see below) of the target URL (disabled by default)
+- `HEALTHCHECK_ENABLED` when enabled, this will proxy /health (no authentication needed) to the given target path (see below) of the target URL (disabled by default)
   - `HEALTHCHECK_TARGET_PATH` target path for the health check on the target url (`PROXY_TARGET_URL`)
   - `HEALTHCHECK_IPS` optional comma separated list of IPs/subnets that are allowed to access the /health endpoint
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ It runs fine on OpenShift and binds port 8080 per default.
 - `IPS_ACCESS_WHITELIST` optional comma separated list of IPs/subnets that are allowed to access the proxy
 - `REMOTE_USER_REGEX` optional regex the `REMOTE_USER` must match against (e.g. `!@example.net$`)
 - `LOG_LEVEL` optional log level for Apache (default is `info`)
+- `HEALTHCHECK_ENABLED` when enabled, this will proxy /health to the given target path (see below) of the target URL (disabled by default)
+  - `HEALTHCHECK_TARGET_PATH` target path for the health check on the target url (`PROXY_TARGET_URL`)
+  - `HEALTHCHECK_IPS` optional comma separated list of IPs/subnets that are allowed to access the /health endpoint
 
 # Testing it locally
 

--- a/docker/httpd.conf.erb
+++ b/docker/httpd.conf.erb
@@ -39,6 +39,11 @@ CustomLog /dev/stdout combined
   ProxyPreserveHost On
   RemoteIPHeader X-Forwarded-For
 
+  <%- if ENV['HEALTHCHECK_ENABLED'] == '1' -%>
+  ProxyPass /health <%= ENV['PROXY_TARGET_URL'] %>/<%= ENV['HEALTHCHECK_TARGET_PATH'] %>
+  ProxyPassReverse /health <%= ENV['PROXY_TARGET_URL'] %>/<%= ENV['HEALTHCHECK_TARGET_PATH'] %>
+  <%- end -%>
+
   ProxyPass / <%= ENV['PROXY_TARGET_URL'] %>
   ProxyPassReverse / <%= ENV['PROXY_TARGET_URL'] %>
 
@@ -71,6 +76,15 @@ CustomLog /dev/stdout combined
     RewriteRule .* - [L,F]
     <%- end -%>
   </Location>
+  <%- end -%>
+
+  <%- if ENV['HEALTHCHECK_ENABLED'] == '1' -%>
+  <LocationMatch "^/health$">
+    AuthType none
+    <%- unless ENV['HEALTHCHECK_IPS'].to_s.empty? -%>
+    Require ip <%= ENV['HEALTHCHECK_IPS'].split(',').join(' ') %>
+    <%- end -%>
+  </LocationMatch>
   <%- end -%>
 
   <Proxy *>


### PR DESCRIPTION
When configured, this will proxy /health to the configured endpoint on
the proxy target.