### PR TITLE
Add mod_auth_openidc as option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:xenial
-MAINTAINER Samuel Sieg samuel.sieg@nine.ch
+FROM ubuntu:bionic
 
 RUN apt-get -qq update && \
     apt-get -qq install -y apache2 \
     libapache2-mod-auth-cas \
+    libapache2-mod-auth-openidc ca-certificates \
     ruby && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ It runs fine on OpenShift and binds port 8080 per default.
   - `CAS_VALIDATE_URL` the CAS validate URL of your CAS service (e.g. https://sso.example.net/serviceValidate)
   - `CAS_PROXY_VALIDATE_URL` the CAS proxy validate URL of your CAS service (e.g. https://sso.example.net/proxyValidate)
   - `CAS_SERVICE_URL` the domain of the service the proxy is running at, usually this is the URL that you connect to this application afterwards, it is used to tell the CAS service where to redirect back
+- `OIDC_ENABLED` enable OpenID Connect authentication (disabled by default)
+  - `OIDC_PROVIDER_METADATA_URL` the metadata url of your OpenID Connect provider (e.g. https://keycloak.example.com/auth/realms/master/.well-known/openid-configuration)
+  - `OIDC_CLIENT_ID` the oidc client id
+  - `OIDC_CLIENT_SECRET` the oidc client secret
+  - `OIDC_REDIRECT_URL` the redirect url of your application
+  - `OIDC_CRYPTO_PASSPHRASE` the passphrase with which Apache encrypts temporary state cookies and cache entries. (see https://github.com/zmartzone/mod_auth_openidc/blob/master/auth_openidc.conf#L16)
 - `IPS_ACCESS_WHITELIST` optional comma separated list of IPs/subnets that are allowed to access the proxy
 - `REMOTE_USER_REGEX` optional regex the `REMOTE_USER` must match against (e.g. `!@example.net$`)
 - `LOG_LEVEL` optional log level for Apache (default is `info`)
@@ -20,11 +26,24 @@ It runs fine on OpenShift and binds port 8080 per default.
   - `HEALTHCHECK_TARGET_PATH` target path for the health check on the target url (`PROXY_TARGET_URL`)
   - `HEALTHCHECK_IPS` optional comma separated list of IPs/subnets that are allowed to access the /health endpoint
 
-# Testing it locally
+## Testing it locally
 
 To run it locally, you can use the following commands:
 
-```
+```sh
 docker build -t docker-reverse-proxy:latest .
 docker run -ti -p 9999:8080 -e PROXY_TARGET_URL='http://example.net/' docker-reverse-proxy
+```
+
+With OpenID Connect authentication (Keycloak for example):
+
+```sh
+docker run -e OIDC_ENABLED=1 \
+           -e OIDC_PROVIDER_METADATA_URL=https://keycloak.domain.com/auth/realms/master/.well-known/openid-configuration \
+           -e OIDC_CLIENT_SECRET=03d6350b-5c29-443a-94a1-2320bb16ef49 \
+           -e OIDC_CLIENT_ID=apache-test \
+           -e OIDC_REDIRECT_URL=http://localhost:8080/oauth2callback \
+           -e OIDC_CRYPTO_PASSPHRASE=QdkxCr3cSdcNCUxHw \
+           -e PROXY_TARGET_URL=http://localhost \
+           -p 8080:8080 apache-test
 ```

--- a/docker/httpd.conf.erb
+++ b/docker/httpd.conf.erb
@@ -50,10 +50,27 @@ CustomLog /dev/stdout combined
   CASValidateURL <%= ENV['CAS_VALIDATE_URL'] %>
   CASProxyValidateURL <%= ENV['CAS_PROXY_VALIDATE_URL'] %>
   CASRootProxiedAs <%= ENV['CAS_SERVICE_URL'] %>
+  <%- end -%>
+
+  <%- if ENV['OIDC_ENABLED'] == '1' -%>
+  LoadModule auth_openidc_module /usr/lib/apache2/modules/mod_auth_openidc.so
+
+  OIDCProviderMetadataURL <%= ENV['OIDC_PROVIDER_METADATA_URL'] %>
+  OIDCClientID <%= ENV['OIDC_CLIENT_ID'] %>
+  OIDCClientSecret <%= ENV['OIDC_CLIENT_SECRET'] %>
+  OIDCRedirectURI <%= ENV['OIDC_REDIRECT_URL'] %>
+  OIDCCryptoPassphrase <%= ENV['OIDC_CRYPTO_PASSPHRASE'] %>
+  OIDCProviderTokenEndpointAuth client_secret_basic
+  <%- end -%>
 
   <Location />
+    <%- if ENV['CAS_ENABLED'] == '1' -%>
     CASScope /
     AuthType cas
+    <%- elsif ENV['OIDC_ENABLED'] == '1' %>
+    AuthType openid-connect
+    <%- end -%>
+
     AuthName "Proxy"
     <RequireAll>
       Require valid-user
@@ -71,7 +88,6 @@ CustomLog /dev/stdout combined
     ProxyPass <%= ENV['PROXY_TARGET_URL'] %>
     ProxyPassReverse <%= ENV['PROXY_TARGET_URL'] %>
   </Location>
-  <%- end -%>
 
   <%- if ENV['HEALTHCHECK_ENABLED'] == '1' -%>
   ProxyPass /<%= ENV['HEALTHCHECK_TARGET_PATH'] %> <%= ENV['PROXY_TARGET_URL'] %><%= ENV['HEALTHCHECK_TARGET_PATH'] %>


### PR DESCRIPTION
This PR adds the possibility to use [mod-auth-openidc](https://github.com/zmartzone/mod_auth_openidc) for OpenID Connect authentication on the proxy level. It kind of has the same behavior as the existing mod-auth-cas integration.

The new configuration options are:

- `OIDC_ENABLED` enable OpenID Connect authentication (disabled by default)
  - `OIDC_PROVIDER_METADATA_URL` the metadata url of your OpenID Connect provider (e.g. https://keycloak.example.com/auth/realms/master/.well-known/openid-configuration)
  - `OIDC_CLIENT_ID` the oidc client id
  - `OIDC_CLIENT_SECRET` the oidc client secret
  - `OIDC_REDIRECT_URL` the redirect url of your application
  - `OIDC_CRYPTO_PASSPHRASE` the passphrase with which Apache encrypts temporary state cookies and cache entries. (see https://github.com/zmartzone/mod_auth_openidc/blob/master/auth_openidc.conf#L16)